### PR TITLE
Updated Exablaze trailer to only use hueristic when required

### DIFF
--- a/record_process.hpp
+++ b/record_process.hpp
@@ -79,6 +79,6 @@ private:
     record_time_t process_compat_keyframe(const read_record_t& record, const char* keyframe, size_t len);
 
     record_time_t process_32bit_timestamps(const read_record_t& record, char* buffer);
-    record_time_t process_trailer_timestamps(const read_record_t& record, char* buffer);
+    record_time_t process_trailer_timestamps(const read_record_t& record, char* buffer, bool force_trailer_mode);
 };
 


### PR DESCRIPTION
There is a bug in the current version, where the heuristic method of decoding Exablaze HPT trailers is invoked, even if the user specifies the --trailer on the command line. This can break if the PCAP headers are taken on an ExaNIC that has not be sync'd using exanic-clock-sync. In this case, there will be a large discrepancy between the PCAP header time, and the HPT trailer time. But, the contents of the HPT trailer is still fine. 

This PR fixes the bug by adding a "forced" mode to the code path. If the user specifies --trailer, then the trailer is assumed to reside at the end of the frame with no extra bytes. 